### PR TITLE
Copy edit index content

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,68 +3,65 @@
 Rackspace Command Line Interface
 ================================
 
-Description
------------
-
-The Rackspace Command Line Interface is a unified tool to manage your Rackspace
-services. It provides streamlined and secure configuration as well as a single
+The Rackspace Command Line Interface (``rack`` CLI) is a unified tool for managing your Rackspace
+services. It provides streamlined and secure configuration and a single
 point of entry for all Rackspace Cloud services.
-
 
 Quickstart
 ----------
 
-For full instructions on how to get started you should read :ref:`installation_and_configuration`.
+For full instructions, see :ref:`installation_and_configuration`.
 
-The tl;dr version is to grab the binary for your platform:
+To get started quickly, perform these steps:
 
-* `Mac OSX (64 bit)`_
-* `Linux (64 bit)`_
-* `Windows (64 bit)`_
+1. Download the binary for your platform:
 
-Once downloaded, you need to make it executable. If you are unfamiliar with this
-or are running Windows, please see :ref:`installation_and_configuration`.
+    * `Mac OS X (64-bit)`_
+    * `Linux (64-bit)`_
+    * `Windows (64-bit)`_
 
-Next, move into the directory where you downloaded the ``rack`` binary and run::
+2. Make the binary executable. If you are unfamiliar with this process or you are running Windows, go to :ref:`installation_and_configuration`.
+
+3. Go to the directory where you downloaded the ``rack`` binary and run the following command::
 
     ./rack configure
 
-This command will automatically create a configuration file for you if it
-doesn't exist and walk you through creating a profile for it::
+   This command automatically creates a configuration file if one doesn't already exist and walks you through creating a profile for it::
 
     This interactive session will walk you through creating
     a profile in your configuration file. You may fill in all or none of the
     values.
 
-    Rackspace Username: iamacat
-    Rackspace API key: secrets
-    Rackspace Region: IAD
+    Rackspace Username: <yourRackspaceUsername>
+    Rackspace API key: <yourRackspaceApiKey>
+    Rackspace Region: <yourRackspaceRegion>
     Profile Name (leave blank to create a default profile):
 
-This allows you to immediately get working::
+After you create the profile, you can immediately start working. For example, you could issue the following command to get a list of the servers on your Rackspace account::
 
     ./rack servers instance list
 
-If the ``rack`` binary isn't on your system's PATH, you'll only be able to run it from the
-directory in which it resides. To run ``rack`` from anywhere, move the binary into a directory
-on your systems PATH. Then, you'll be able to run it from anywhere::
+.. tip::
+    Add the directory in which the ``rack`` binary resides to your system's PATH environment variable. Then, you can run it from anywhere, as shown in the following example::
 
-    rack servers instance list
+      rack servers instance list
 
 
-Synopsis
+Overview
 --------
 
-::
+All ``rack`` CLI commands use the following pattern::
 
-    rack <service> <subservice> <action> [flags]
+    rack <command> <subcommand> <action> [flags]
+    
+.. note::
+    ``<command>`` is usually equivalent to a Rackspace service.  
 
-All ``rack`` commands follow the pattern above - for example, if you wanted to
-list all servers on your Rackspace account, you would type::
+For example, to list all servers on your Rackspace account, you would issue the following command::
 
   rack servers instance list
 
-And the response (**default**: table-based output) would look like::
+The response, which is table-based output by default, would look as follows::
 
       ID	Name		Status	Public IPv4	Private IPv4	Image	Flavor
       GUID	my_server	ACTIVE	101.130.19.31	10.208.128.233	GUID	io1-30
@@ -73,38 +70,23 @@ Global Options
 --------------
 
 The ``rack`` CLI uses global options to alter output, authenticate, or
-pass in other **global** information into the tool. These options are
-called global because they are valid for any command. To see these, see :ref:`global_options`.
+pass in other global information into the tool. These options are
+called *global* because they are valid for any command. To see a list of these options, go to :ref:`global_options`.
 
 Services
 --------
 
-* :ref:`servers` - Commands for Rackspace Cloud Servers, dedicated and virtual.
-* :ref:`files` - Commands for Rackspace Cloud Files.
-* :ref:`networks` - Commands for Rackspace Cloud Networks.
-* :ref:`block_storage` - Commands for Rackspace Block Storage.
+The ``rack`` CLI provides commands for interacting with the following Rackspace Cloud services:
+
+* :ref:`servers` - Commands for Rackspace Cloud Servers, dedicated and virtual
+* :ref:`files` - Commands for Rackspace Cloud Files
+* :ref:`block_storage` - Commands for Rackspace Cloud Block Storage
+* :ref:`networks` - Commands for Rackspace Cloud Networks
 * :ref:`orchestration` - Commands for Rackspace Cloud Orchestration
 
 
-.. toctree::
-   :caption: Contents
-   :name: mastertoc
-   :maxdepth: 2
-
-   configuration.rst
-   globaloptions.rst
-   services/index.rst
-   troubleshooting.rst
-
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`search`
-
 .. _Github project: https://github.com/rackspace/rack
-.. _Mac OSX (64 bit): https://ec4a542dbf90c03b9f75-b342aba65414ad802720b41e8159cf45.ssl.cf5.rackcdn.com/1.1.1/Darwin/amd64/rack
-.. _Linux (64 bit): https://ec4a542dbf90c03b9f75-b342aba65414ad802720b41e8159cf45.ssl.cf5.rackcdn.com/1.1.1/Linux/amd64/rack
-.. _Windows (64 bit): https://ec4a542dbf90c03b9f75-b342aba65414ad802720b41e8159cf45.ssl.cf5.rackcdn.com/1.1.1/Windows/amd64/rack.exe
+.. _Mac OS X (64-bit): https://ec4a542dbf90c03b9f75-b342aba65414ad802720b41e8159cf45.ssl.cf5.rackcdn.com/1.1.1/Darwin/amd64/rack
+.. _Linux (64-bit): https://ec4a542dbf90c03b9f75-b342aba65414ad802720b41e8159cf45.ssl.cf5.rackcdn.com/1.1.1/Linux/amd64/rack
+.. _Windows (64-bit): https://ec4a542dbf90c03b9f75-b342aba65414ad802720b41e8159cf45.ssl.cf5.rackcdn.com/1.1.1/Windows/amd64/rack.exe
 .. _Cloud Control panel: https://mycloud.rackspace.com/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,7 +70,7 @@ Global Options
 --------------
 
 The ``rack`` CLI uses global options to alter output, authenticate, or
-pass in other global information into the tool. These options are
+pass other global information into the tool. These options are
 called *global* because they are valid for any command. To see a list of these options, go to :ref:`global_options`.
 
 Services


### PR DESCRIPTION
In addition to copy edits, I removed the contents list and tables/indices list from the end of the topic. Links to the rest of the guide should be in the left nav pane, and the links under "Indices and tables" did not work anyway.
